### PR TITLE
Fixed install_px condition. Added symlink to docker binary

### DIFF
--- a/digitalocean/scripts/post_install.sh
+++ b/digitalocean/scripts/post_install.sh
@@ -44,6 +44,9 @@ else
 # Install docker
     curl -fsSL https://get.docker.com/ | sudo sh
 
+#
+# Create symlink to docker binary
+    ln -s /usr/bin/docker /bin/docker 
 fi
 
 

--- a/do_functions.py
+++ b/do_functions.py
@@ -56,7 +56,7 @@ def do_output_json(drop_objs, user_prefix, inst_px):
                                 "DockerDisk": docker_disk,
                                 "Disks": other_disks}
                 json_out.append(drop_details)
-                if inst_px is True:
+                if inst_px:
                     px_installed, px_msg = install_px(public_ip, adm_user, adm_pass)
                     if px_installed:
                         print "INFO : Portworx installed successfully on {}".format(public_ip)


### PR DESCRIPTION
`px-test` expects docker CLI binary to be present in `/bin/` folder while `px-ptool` installs it in `/usr/bin`. Create a symlink to fix it.